### PR TITLE
fix default bus

### DIFF
--- a/Software/Source/fedora-base/pijuice-base.spec
+++ b/Software/Source/fedora-base/pijuice-base.spec
@@ -80,7 +80,7 @@ ln -s pijuiceboot64 pijuiceboot
 ln -s pijuice_cli64 pijuice_cli
 popd
 
-echo "{\"system_task\":{\"enabled\": __SYSTEM_TASK_ENABLED__},\"board\":{\"general\":{\"i2c_bus\": __I2C_BUS__}}}" > %{buildroot}%{_sharedstatedir}/pijuice/pijuice_config.JSON
+echo "{\"system_task\":{\"enabled\": __SYSTEM_TASK_ENABLED__},\"board\":{\"general\":{\"i2c_bus\": 1}}}" > %{buildroot}%{_sharedstatedir}/pijuice/pijuice_config.JSON
 touch %{buildroot}%{_sharedstatedir}/pijuice/pijuice_i2cbus
 
 

--- a/Software/Source/src/pijuice_i2cbus.sh
+++ b/Software/Source/src/pijuice_i2cbus.sh
@@ -70,7 +70,7 @@ find_bus() {
 
 save_bus() {
     echo "I2C_BUS=$I2C_BUS" > "$I2CBUS_CONFIG_FILE"
-    sed -i "s/\(\s*\"i2c_bus\":\s*\)[[:digit:]]\+/\1$I2C_BUS/" $PIJUICE_CONFIG_FILE
+    sed -i "s/\(.*\"i2c_bus\":\s*\)[[:digit:]]\+\(.*\)/\1$I2C_BUS\2/" $PIJUICE_CONFIG_FILE
 }
 
 main "$@"


### PR DESCRIPTION
When installing, we don't need to use a template variable. Just set to 1 and let the start up address the value.