### PR TITLE
Bump version to 6

### DIFF
--- a/Software/Source/fedora-base/pijuice-base.spec
+++ b/Software/Source/fedora-base/pijuice-base.spec
@@ -1,6 +1,6 @@
 Name:           pijuice-base
 Version:        __version__
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Basic support for Pi-Supply's PiJuice HAT
 
 License:        GPLv3+


### PR DESCRIPTION
Bumping the spec version to 6. Still is the base 1.8 version from PiJuice people.