### PR TITLE
changes to fix base package for fc43

### DIFF
--- a/Software/Source/data/98-local_i2c_group.rules
+++ b/Software/Source/data/98-local_i2c_group.rules
@@ -1,1 +1,1 @@
-KERNEL=="i2c-[0-9]*", GROUP="i2c"
+KERNEL=="i2c-[0-9]*", GROUP="i2c", MODE="0660"

--- a/Software/Source/fedora-base/pijuice-base.spec
+++ b/Software/Source/fedora-base/pijuice-base.spec
@@ -1,6 +1,6 @@
 Name:           pijuice-base
 Version:        __version__
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Basic support for Pi-Supply's PiJuice HAT
 
 License:        GPLv3+

--- a/Software/Source/src/pijuice_i2cbus.sh
+++ b/Software/Source/src/pijuice_i2cbus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 CONFIG_FOLDER="/var/lib/pijuice"
 I2CBUS_CONFIG_FILE="$CONFIG_FOLDER/pijuice_i2cbus"
@@ -62,7 +62,7 @@ wake_rtc() {
 }
 
 find_bus() {
-    for f in $(ls -d /sys/class/i2c-dev/*); do
+    for f in $(/bin/ls -d /sys/class/i2c-dev/*); do
         TEMP_I2C_BUS=$(sed -n 's/^MINOR=\([[:digit:]]\+\)/\1/p' $f/uevent)
         # bang it 3 times fast to wake it up
         for i in {1..3}; do
@@ -78,7 +78,7 @@ find_bus() {
 
 save_bus() {
     echo "I2C_BUS=$I2C_BUS" > "$I2CBUS_CONFIG_FILE"
-    sed -i "s/\(.*\"i2c_bus\":\s*\)[[:digit:]]\+\(.*\)/\1$I2C_BUS\2/" $PIJUICE_CONFIG_FILE
+    sed -i "s/\(.*\"i2c_bus\":\s*\)[[:digit:]]*\(.*\)/\1$I2C_BUS\2/" $PIJUICE_CONFIG_FILE
 }
 
 main "$@"


### PR DESCRIPTION
* i2c devices don't allow group r/w
* support missing digit in config file when updating
* when searching i2c dev files don't use shell ls which has special characters
* bump package version