### PR TITLE
fix perms for user of pijuice gui

### DIFF
--- a/Software/Source/fedora-base/pijuice-base.spec
+++ b/Software/Source/fedora-base/pijuice-base.spec
@@ -140,9 +140,9 @@ fi
 
 %attr(4755,pijuice,pijuice) %{_bindir}/pijuice_cli64
 
-%attr(700,pijuice,pijuice) %dir %{_sharedstatedir}/pijuice
-%config(noreplace) %attr(600,pijuice,pijuice) %{_sharedstatedir}/pijuice/pijuice_config.JSON
-%config %attr(600,pijuice,pijuice) %{_sharedstatedir}/pijuice/pijuice_i2cbus
+%attr(770,pijuice,pijuice) %dir %{_sharedstatedir}/pijuice
+%config(noreplace) %attr(660,pijuice,pijuice) %{_sharedstatedir}/pijuice/pijuice_config.JSON
+%config %attr(660,pijuice,pijuice) %{_sharedstatedir}/pijuice/pijuice_i2cbus
 
 
 %changelog


### PR DESCRIPTION
If you run pijuice_gui from the command line, you need access to the state folder.