### PR TITLE
Gnome version needs to be declared

### DIFF
--- a/Software/Source/data/tray@pijuice.org/metadata.json
+++ b/Software/Source/data/tray@pijuice.org/metadata.json
@@ -3,7 +3,7 @@
   "description": "A gnome extension to show status and actions.",
   "uuid": "tray@pijuice.org",
   "shell-version": [
-    "49"
+    "49", "50", "51"
   ],
   "version": 1
 }


### PR DESCRIPTION
This is a headache. gnome requires us to say which version it works in so needs to be bumped every time. Let's add 51 for good measure. I might not be using this device for much longer.